### PR TITLE
Add team_resource_id for header bb-slackteamresourceid

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,9 @@ module.exports = () => {
       // additional bot and team meta-data
       bot_user_name: req.headers['bb-slackbotusername'],
       team_name: req.headers['bb-slackteamname'],
-      team_domain: req.headers['bb-slackteamdomain']
+      team_domain: req.headers['bb-slackteamdomain'],
+      // Beep Boop specific ID for App/Team association
+      team_resource_id: req.headers['bb-slackteamresourceid']
     })
 
     next()


### PR DESCRIPTION
Pulls `team_resource_id` value from HTTP header `bb-slackteamresourceid`

![small](https://cloud.githubusercontent.com/assets/30455/17821829/e95379a4-6610-11e6-916b-0bffe4089899.gif)
