### PR TITLE
adds incoming webhook props parsed from headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ This is an implementation of a context middleware function for
 + `bot_user_name`
 + `team_name`
 + `team_domain`
++ `incoming_webhook_url`
++ `incoming_webhook_channel`
 
 ## Install
 

--- a/index.js
+++ b/index.js
@@ -26,7 +26,10 @@ module.exports = () => {
       team_name: req.headers['bb-slackteamname'],
       team_domain: req.headers['bb-slackteamdomain'],
       // Beep Boop specific ID for App/Team association
-      team_resource_id: req.headers['bb-slackteamresourceid']
+      team_resource_id: req.headers['bb-slackteamresourceid'],
+      // Incoming webhook props
+      incoming_webhook_url: req.headers['bb-incomingwebhookurl'],
+      incoming_webhook_channel: req.headers['bb-incomingwebhookchannel']
     })
 
     next()

--- a/test/context.test.js
+++ b/test/context.test.js
@@ -5,7 +5,7 @@ const sinon = require('sinon')
 const LookupTokens = require('../index')
 
 test.cb('LookupToken()', t => {
-  t.plan(7)
+  t.plan(9)
 
   let mw = LookupTokens()
   let headers = getMockHeaders()
@@ -21,6 +21,8 @@ test.cb('LookupToken()', t => {
     t.is(req.slapp.meta.bot_user_name, headers['bb-slackbotusername'])
     t.is(req.slapp.meta.team_name, headers['bb-slackteamname'])
     t.is(req.slapp.meta.team_domain, headers['bb-slackteamdomain'])
+    t.is(req.slapp.meta.incoming_webhook_url, headers['bb-incomingwebhookurl'])
+    t.is(req.slapp.meta.incoming_webhook_channel, headers['bb-incomingwebhookchannel'])
     t.end()
   })
 })
@@ -111,6 +113,8 @@ function getMockHeaders (headers) {
     'bb-slackbotuserid': 'slackbotuserid',
     'bb-slackbotusername': 'slackbotusername',
     'bb-slackteamname': 'slackteamname',
-    'bb-slackteamdomain': 'slackteamdomain'
+    'bb-slackteamdomain': 'slackteamdomain',
+    'bb-incomingwebhookurl': 'incomingwebhookurl',
+    'bb-incomingwebhookchannel': 'incomingwebhookchannel'
   }, headers || {})
 }


### PR DESCRIPTION
Parses out the incoming webhook url and channels and sets them on the meta prop as the following:
- `incoming_webhook_url`
- `incoming_webhook_channel`
