### PR TITLE
Continue on bb-error, set new meta.error property

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This is an implementation of a context middleware function for
 + `incoming_webhook_url`
 + `incoming_webhook_channel`
 + `config` (team-specific config)
++ `error`
 
 ## Install
 

--- a/index.js
+++ b/index.js
@@ -3,11 +3,6 @@
 // Enrich `req.slapp.meta` with context parsed from Beep Boop headers
 module.exports = () => {
   return function contextMiddleware (req, res, next) {
-    if (req.headers['bb-error']) {
-      console.error('Event: Error: ' + req.headers['bb-error'])
-      return res.send(req.headers['bb-error'])
-    }
-
     if (!req.slapp) {
       return res.send('Missing req.slapp')
     }
@@ -31,7 +26,8 @@ module.exports = () => {
       team_resource_id: req.headers['bb-slackteamresourceid'],
       // Incoming webhook props
       incoming_webhook_url: req.headers['bb-incomingwebhookurl'],
-      incoming_webhook_channel: req.headers['bb-incomingwebhookchannel']
+      incoming_webhook_channel: req.headers['bb-incomingwebhookchannel'],
+      error: req.headers['bb-error']
     })
 
     // Add custom config

--- a/test/context.test.js
+++ b/test/context.test.js
@@ -29,7 +29,7 @@ test.cb('LookupToken()', t => {
   })
 })
 
-test('LookupToken() error header', t => {
+test.cb('LookupToken() error header', t => {
   let mw = LookupTokens()
   let headers = getMockHeaders({
     'bb-error': 'kaboom'
@@ -38,13 +38,10 @@ test('LookupToken() error header', t => {
   let req = getMockReq({ headers })
   let res = getMockRes()
 
-  let sendStub = sinon.stub(res, 'send')
-
   mw(req, res, () => {
-    t.fail()
+    t.is(req.slapp.meta.error, 'kaboom')
+    t.end()
   })
-
-  t.true(sendStub.calledOnce)
 })
 
 test.cb('LookupToken() team config headers', t => {
@@ -64,30 +61,6 @@ test.cb('LookupToken() team config headers', t => {
     t.is(req.slapp.meta.config['CUSTOM_TOKEN2'], 'customtoken2value')
     t.end()
   })
-})
-
-test('LookupToken() error header w/ logger', t => {
-  let logger = {
-    error: () => {}
-  }
-  let mw = LookupTokens({ logger })
-  let headers = getMockHeaders({
-    'bb-error': 'kaboom'
-  })
-
-  let req = getMockReq({ headers })
-  let res = getMockRes()
-
-  let sendStub = sinon.stub(res, 'send')
-  let logStub = sinon.stub(console, 'error')
-
-  mw(req, res, () => {
-    t.fail()
-  })
-
-  t.true(sendStub.calledOnce)
-  t.true(logStub.calledOnce)
-  console.error.restore()
 })
 
 test('LookupToken() missing req.slapp', t => {


### PR DESCRIPTION
Related to this issue, if there is a `bb-error` header, continue processing vs logging to stderr and immediately responding. I removed the log statement and replaced it with a new property `meta.error`.  

Related to:
https://github.com/BeepBoopHQ/slapp/pull/71